### PR TITLE
Remove useless test count column

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,10 +98,7 @@ exports['default'] = function () {
       this.tableReports += this.indentString('<td>', 2);
       this.tableReports += this.uaList;
       this.tableReports += '</td>\n';
-      // TestCount
-      this.tableReports += this.indentString('<td>', 2);
-      this.tableReports += this.testCount;
-      this.tableReports += '</td>\n';
+
       // Duration
       this.tableReports += this.indentString('<td>', 2);
       this.tableReports += this.moment.duration(testRunInfo.durationMs).format('h[h] mm[m] ss[s]');
@@ -152,7 +149,6 @@ exports['default'] = function () {
       html += '<th>Fixture</th>';
       html += '<th>Test Name</th>';
       html += '<th>Browsers</th>';
-      html += '<th>Test Count</th>';
       html += '<th>Duration</th>';
       html += '<th>Result</th>';
       html += '</tr>';


### PR DESCRIPTION
Removes test count column since it always contains total tests count not an iterable test number

![image](https://user-images.githubusercontent.com/8017482/43798989-dc729142-9a94-11e8-9716-9f083aae68f0.png)
