### PR TITLE
Add link to error details

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ exports['default'] = function () {
     tableReports: '',
     testCount: 0,
     skipped: 0,
+    currentTestNumber: 1,
 
     reportTaskStart: function reportTaskStart(startTime, userAgents, testCount) {
       this.startTime = startTime;
@@ -62,14 +63,16 @@ exports['default'] = function () {
       if (hasErr) {
         this.compileErrors(name, testRunInfo);
       }
+
+      this.currentTestNumber += 1;
     },
 
     compileErrors: function compileErrors(name, testRunInfo) {
       var _this = this;
 
-      var heading = this.currentFixtureName + ' - ' + name;
+      var heading = `${this.currentTestNumber}. ${this.currentFixtureName} - ${name}`;
 
-      this.report += this.indentString('<h4>' + heading + '</h4>\n');
+      this.report += this.indentString(`<h4 id="test-${this.currentTestNumber}">${heading}</h4>\n`);
       testRunInfo.errs.forEach(function (error) {
         _this.report += _this.indentString('<pre>');
         _this.report += _this.formatError(error, '');
@@ -85,6 +88,11 @@ exports['default'] = function () {
       } else {
         this.tableReports += this.indentString('<tr class="success">\n');
       }
+
+      // Number
+      this.tableReports += this.indentString('<td>', 2);
+      this.tableReports += this.currentTestNumber;
+      this.tableReports += '</td>\n';
 
       // Fixture
       this.tableReports += this.indentString('<td>', 2);
@@ -110,6 +118,8 @@ exports['default'] = function () {
       this.tableReports += this.indentString('<td>', 2);
       if (testRunInfo.skipped) {
         this.tableReports += 'skipped';
+      } else if (result === 'failed') {
+        this.tableReports += `<a href="#test-${this.currentTestNumber}">failed</a>`;
       } else {
         this.tableReports += result;
       }
@@ -149,6 +159,7 @@ exports['default'] = function () {
       // Summary table
       html += '<table class="table ">';
       html += '<tr>';
+      html += '<th>#</th>';
       html += '<th>Fixture</th>';
       html += '<th>Test Name</th>';
       html += '<th>Browsers</th>';


### PR DESCRIPTION
Adds links for failed tests so error details could be easily accessed (suppresses #2 )

![image](https://user-images.githubusercontent.com/8017482/43826331-c0c89d18-9aff-11e8-80f7-a60f49586f82.png)
