### PR TITLE
fix: image modal to be 75% of screen size, not fixed to 700px

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ module.exports = () => ({
         margin: auto;
         display: block;
         width: 80%;
-        max-width: 700px;
+        max-width: 75%;
       }
 
       .closeModal {

--- a/test/data/report-with-colors.html
+++ b/test/data/report-with-colors.html
@@ -44,7 +44,7 @@
         margin: auto;
         display: block;
         width: 80%;
-        max-width: 700px;
+        max-width: 75%;
       }
 
       .closeModal {


### PR DESCRIPTION
I was working on a 4K monitor and noticed that the image in the modal (upon clicking the thumbnail) was too small to make out details. I think making the image size to adapt to % of windows size would always make the best use of the screen real estate available.